### PR TITLE
♻️ Use samples instead of hard-coded value

### DIFF
--- a/CGGradient+.swift
+++ b/CGGradient+.swift
@@ -50,7 +50,7 @@ extension CGGradient{
         }
         
         
-        for i in 0...24 {
+        for i in 0...samples {
             let tt = CGFloat(i)/CGFloat(samples)
             
             // calculate t based on easing function provided


### PR DESCRIPTION
You defined the `samples` variable but don't reuse it. This should then also allow for setting samples from caller functions in the future